### PR TITLE
switch from ifc-core to reflifc

### DIFF
--- a/tools/neat_code_gen/CMakeLists.txt
+++ b/tools/neat_code_gen/CMakeLists.txt
@@ -14,7 +14,7 @@
 	FetchContent_Declare(
 		ifc-reader
 		GIT_REPOSITORY https://github.com/AndreyG/ifc-reader.git
-		GIT_TAG 3cd0d09c9b1cff645d17a8d725d1162719197c6f # Latest at the time of writing
+		GIT_TAG fa4dd3e92f0a2bb241459c217f9b4e0696d27b19 # Latest at the time of writing
 	)
 	FetchContent_Declare(
 		magic_enum
@@ -35,7 +35,7 @@
 	add_executable(NeatReflectionCodeGen "src/Main.cpp" "src/CodeGenerator.h" "src/CodeGenerator.cpp" "src/ContextualException.h" "src/ContextualException.cpp")
 	target_compile_features(NeatReflectionCodeGen PUBLIC cxx_std_20)
 	target_include_directories(NeatReflectionCodeGen PRIVATE "src")
-	target_link_libraries(NeatReflectionCodeGen PUBLIC NeatReflection docopt_s ifc-core magic_enum mio)
+	target_link_libraries(NeatReflectionCodeGen PUBLIC NeatReflection docopt_s reflifc magic_enum mio)
 
 	message(DEBUG "[NeatReflection] Using NeatReflectionCodeGen built from source.")
 	set(NEAT_REFLECTION_CODEGEN_EXE "NeatReflectionCodeGen" PARENT_SCOPE)

--- a/tools/neat_code_gen/src/Main.cpp
+++ b/tools/neat_code_gen/src/Main.cpp
@@ -73,8 +73,8 @@ bool convert_ifc_file(const std::string& ifc_filename, const std::string& cpp_fi
         return false;
     }
 
-    CodeGenerator code_generator{ ifc_file };
-    code_generator.write_cpp_file(file_stream);
+    CodeGenerator code_generator;
+    code_generator.write_cpp_file(reflifc::Module(ifc_file), file_stream);
 
     return true;
 }


### PR DESCRIPTION
I have created a little bit more high-level interface for work with IFC -- `ReflIFC`, wrapper around ifc-core. IMO it makes sense to switch from direct using of `ifc-core` to `reflifc`.